### PR TITLE
Adapting to work with environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22
+
+# Set the working directory in the container
+WORKDIR /app
+
+ADD dist /app
+
+# Install http-server globally
+RUN npm install -g http-server
+
+# Make port 8080 available to the world outside this container
+EXPOSE 8083
+
+# Run http-server when the container launches
+CMD ["http-server", "dist", "-p", "8083"]
+
+RUN 
+

--- a/Dockerfile-ws
+++ b/Dockerfile-ws
@@ -1,0 +1,19 @@
+FROM node:22
+
+# Set the working directory in the container
+WORKDIR /app
+
+ADD . /app
+
+# Install websocket server 
+
+# Make port 8080 available to the world outside this container
+EXPOSE 8001
+
+ENV NODE_ENV=development
+
+# Run websocket server when the container launches
+CMD ["node", "server/index.js"]
+
+RUN 
+

--- a/docker/.env-example
+++ b/docker/.env-example
@@ -1,0 +1,3 @@
+CT_WEBSOCKET_SERVER=ws.domain.com
+CT_HOSTNAME=clocktower.domain.com
+NODE_ENV=nossl

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,12 +1,13 @@
 services:
   clocktower:
     build:
-      context: .. 
-      dockerfile: Dockerfile
+      context: .. # Where to find Dockerfile
+      dockerfile: Dockerfile # Dockerfile to build from
     ports: 
-      - 8083:8083
+      - 8083:8083 # Ports to expose
     environment: 
-      - CT_WEBSOCKET=ws.mduck.net
+      - CT_WEBSOCKET=ws.mduck.net # Where will websocket host be accessible
+    restart: unless-stopped # Restart unless container manually stopped
   websocket:
     build:
       context: ..
@@ -16,4 +17,4 @@ services:
       - NODE_ENV=nossl
     ports:
       - 8001:8001
-
+    restart: unless-stopped

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,19 @@
+services:
+  clocktower:
+    build:
+      context: .. 
+      dockerfile: Dockerfile
+    ports: 
+      - 8083:8083
+    environment: 
+      - CT_WEBSOCKET=ws.mduck.net
+  websocket:
+    build:
+      context: ..
+      dockerfile: Dockerfile-ws
+    environment:
+      - CT_HOSTNAME=clocktower.mduck.net
+      - NODE_ENV=nossl
+    ports:
+      - 8001:8001
+

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -1,6 +1,7 @@
+
 class LiveSession {
   constructor(store) {
-    this._wss = "wss://clocktower.live:8001/";
+    this._wss = process.env.CT_WEBSOCKET || "ws://clocktower.live:8081";
     // this._wss = "ws://localhost:8081/"; // uncomment if using local server with NODE_ENV=development
     this._socket = null;
     this._isSpectator = true;


### PR DESCRIPTION
This PR is pulling together what we need to make the Docker containers more generalized. All settings will be pulled out to a `.env` file, which I have an example of `.env-example` in this PR. 

This PR adapts configuration to be set in an environment file....

I've also renamed the value for `NODE_ENV`, `development` to a more appropriate `nossl`

Run like: 
```
node --env-file=docker/.env server.js 
```